### PR TITLE
Configure Vite base path for multi-platform deployment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/lexik3-web/',
+  base: process.env.NODE_ENV === 'production' && process.env.VERCEL ? '/' : '/lexik3-web/',
   server: {
     port: 3000,
     open: true


### PR DESCRIPTION
## 🐛 Problem
The app was failing to load on Vercel due to incorrect asset paths. The base path was hardcoded to `/lexik3-web/` which is required for GitHub Pages but causes 404 errors on Vercel.

## ✅ Solution
Updated `vite.config.js` to dynamically set the base path based on the deployment platform:

- **Vercel**: Uses `/` (root path) - no prefix needed
- **GitHub Pages**: Uses `/lexik3-web/` - maintains repository name prefix
- **Automatic Detection**: Uses environment variables to determine the correct base path

## �� Technical Changes
```javascript
// Before
base: '/lexik3-web/',

// After  
base: process.env.NODE_ENV === 'production' && process.env.VERCEL ? '/' : '/lexik3-web/',
```

## 🚀 Benefits
- ✅ **Vercel**: Assets load correctly from root paths
- ✅ **GitHub Pages**: Maintains compatibility with repository structure
- ✅ **Multi-platform**: Single codebase works on both platforms
- ✅ **Automatic**: No manual configuration needed

## �� Testing
- [x] Vercel deployment loads correctly
- [x] GitHub Pages deployment still works
- [x] All assets (JS, CSS) load properly
- [x] No 404 errors on either platform

## 📱 Impact
- Fixes the `NS_ERROR_CORRUPTED_CONTENT` and 404 errors on Vercel
- Maintains backward compatibility with GitHub Pages
- Improves user experience across all deployment platforms

This ensures the LexiK3 app works seamlessly on both Vercel and GitHub Pages without any manual configuration changes.